### PR TITLE
Update build.gradle to support import module

### DIFF
--- a/songbird/build.gradle
+++ b/songbird/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.yahoo.finance'
-version = sdk_version
+version = "1.0.1"
 project.ext.artifactId = 'songbird'
 
 apply plugin: 'com.android.library'
@@ -12,7 +12,7 @@ android {
     buildToolsVersion "29.0.2"
 
     defaultConfig {
-        minSdkVersion deps.build.minSdkVersion
+        minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
@@ -30,9 +30,9 @@ android {
 }
 
 dependencies {
-    implementation deps.android.material
-    implementation deps.android.annotations
-    implementation deps.android.ktx
+    implementation "com.google.android.material:material:1.0.0"
+    implementation "androidx.annotation:annotation:1.0.0"
+    implementation "androidx.core:core-ktx:1.0.0"
 }
 
 repositories {


### PR DESCRIPTION
While importing this project I found it was missing several references to the ext.sdk_version and dependencies file so I've hardcoded them here to make it easy to use out of the box

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
